### PR TITLE
Allow more flexibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ None
 * `logcheck_install`: [default: `[logcheck, syslog-summary]`]: Packages to install
 * `logcheck_reportlevel`: [default: `server`]: Controls the level of filtering
 * `logcheck_sendmailto`: [default: `root`]: Controls the address mail goes to
-* `logcheck_syslogsummary`: [default: `true`]: Controls if syslog-summary is run over each section
 * `logcheck_logfiles`: [default: `[/var/log/{syslog,auth.log,mail.log,kern.log]`]: Log files to check
 * `logcheck_custom_ignores`: [default: `[]`]: Additional rules for lines to ignore
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ None
 * `logcheck_sendmailto`: [default: `root`]: Controls the address mail goes to
 * `logcheck_logfiles`: [default: `[/var/log/{syslog,auth.log,mail.log,kern.log]`]: Log files to check
 * `logcheck_custom_ignores`: [default: `[]`]: Additional rules for lines to ignore
+* `logcheck_rulesdir`: [default: undefined (default of logcheck which is `/etc/logcheck/`)]: Change the directory where logcheck will look for it’s rules.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,4 @@ logcheck_logfiles:
   - /var/log/mail.log
   - /var/log/kern.log
 logcheck_custom_ignores: []
-logcheck_manage_cronjob: False
-
-# logcheck_rulesdir: '/etc/logcheck'
+logcheck_manage_cronjob: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,9 +6,13 @@ logcheck_install:
 logcheck_reportlevel: server
 logcheck_sendmailto: root
 logcheck_syslogsummary: true
+logcheck_sortuniq: false
 logcheck_logfiles:
   - /var/log/syslog
   - /var/log/auth.log
   - /var/log/mail.log
   - /var/log/kern.log
 logcheck_custom_ignores: []
+logcheck_manage_cronjob: False
+
+# logcheck_rulesdir: '/etc/logcheck'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,6 @@ logcheck_install:
   - syslog-summary
 logcheck_reportlevel: server
 logcheck_sendmailto: root
-logcheck_syslogsummary: true
 logcheck_sortuniq: false
 logcheck_logfiles:
   - /var/log/syslog

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 # tasks file for logcheck
 ---
-- name: install
+- name: Ensure logcheck related packages are installed
   apt:
     name: "{{ item }}"
     state: latest
@@ -35,6 +35,7 @@
     group: root
     mode: 0644
     force: yes
+  when: logcheck_manage_cronjob
   tags: [configuration, logcheck, logcheck-cron-d]
 
 - name: update (custom) ignore.d rules

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 # tasks file for logcheck
 ---
-- name: Ensure logcheck related packages are installed
+- name: install
   apt:
     name: "{{ item }}"
     state: latest

--- a/templates/etc/logcheck/logcheck.conf.j2
+++ b/templates/etc/logcheck/logcheck.conf.j2
@@ -65,7 +65,7 @@ RULEDIR="{{ logcheck_rulesdir }}"
 # Alternatively, set to "1" to enable extra summary.
 # HINT: syslog-summary needs to be installed.
 
-SYSLOGSUMMARY={{ '1' if (logcheck_syslogsummary and 'syslog-summary' in logcheck_install) else '0' }}
+SYSLOGSUMMARY={{ '1' if 'syslog-summary' in logcheck_install else '0' }}
 
 # Controls Subject: lines on logcheck reports:
 

--- a/templates/etc/logcheck/logcheck.conf.j2
+++ b/templates/etc/logcheck/logcheck.conf.j2
@@ -44,7 +44,7 @@ FQDN=1
 # default is to use "sort -k 1,3 -s":
 # Alternatively, set to "1" to enable unique sorting
 
-SORTUNIQ=0
+SORTUNIQ={{ '1' if logcheck_sortuniq else '0' }}
 
 # Controls whether /etc/logcheck/cracking.ignore.d is scanned for
 # exceptions to the rules in /etc/logcheck/cracking.d:
@@ -55,13 +55,17 @@ SORTUNIQ=0
 # Controls the base directory for rules file location
 # This must be an absolute path
 
+{% if logcheck_rulesdir is string and logcheck_rulesdir %}
+RULEDIR="{{ logcheck_rulesdir }}"
+{% else %}
 #RULEDIR="/etc/logcheck"
+{% endif %}
 
 # Controls if syslog-summary is run over each section.
 # Alternatively, set to "1" to enable extra summary.
 # HINT: syslog-summary needs to be installed.
 
-SYSLOGSUMMARY={{ '1' if logcheck_syslogsummary else '0' }}
+SYSLOGSUMMARY={{ '1' if (logcheck_syslogsummary and 'syslog-summary' in logcheck_install) else '0' }}
 
 # Controls Subject: lines on logcheck reports:
 

--- a/templates/etc/logcheck/logcheck.conf.j2
+++ b/templates/etc/logcheck/logcheck.conf.j2
@@ -55,7 +55,7 @@ SORTUNIQ={{ '1' if logcheck_sortuniq else '0' }}
 # Controls the base directory for rules file location
 # This must be an absolute path
 
-{% if logcheck_rulesdir is string and logcheck_rulesdir %}
+{% if logcheck_rulesdir is defined %}
 RULEDIR="{{ logcheck_rulesdir }}"
 {% else %}
 #RULEDIR="/etc/logcheck"


### PR DESCRIPTION
Change sorting, disable cron job overwrite and change log dir.

Note that this PR disables cron management by default because the defaults from distributions are usually fine and this role does not allow any flexibility in this regard.
See https://github.com/weareinteractive/ansible-cron for cron example.