### PR TITLE
turn cron entry into template to expose cron schedule in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ None
 * `logcheck_sortuniq`: [default: `false`]: Controls whether `sort -u` is used on log entries
 * `logcheck_rulesdir`: [optional]: Controls the base directory for rules file location, this must be an absolute path
 * `logcheck_manage_cron_d`: [default: `true`]: Whether or not to manage `/etc/cron.d/logcheck`
+* `logcheck_cron`: [default: `@daily`]: cron.d timestamp when to execute logcheck
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,4 @@ logcheck_logfiles:
   - /var/log/kern.log
 logcheck_custom_ignores: []
 logcheck_manage_cron_d: true
+logcheck_cron: "@daily"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,8 +35,8 @@
   tags: [configuration, logcheck, logcheck-configuration]
 
 - name: update cron.d script
-  copy:
-    src: etc/cron.d/logcheck
+  template:
+    src: etc/cron.d/logcheck.j2
     dest: /etc/cron.d/logcheck
     owner: root
     group: root

--- a/templates/etc/cron.d/logcheck.j2
+++ b/templates/etc/cron.d/logcheck.j2
@@ -1,9 +1,10 @@
 # /etc/cron.d/logcheck: crontab entries for the logcheck package
+# {{ ansible_managed }}
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 MAILTO=root
 
 @reboot         logcheck    if [ -x /usr/sbin/logcheck ]; then nice -n10 /usr/sbin/logcheck -R; fi
-@daily          logcheck    if [ -x /usr/sbin/logcheck ]; then nice -n10 /usr/sbin/logcheck; fi
+{{ logcheck_cron }}          logcheck    if [ -x /usr/sbin/logcheck ]; then nice -n10 /usr/sbin/logcheck; fi
 
 # EOF


### PR DESCRIPTION
My setup requires to run logcheck hourly, like in the original distribution setup. This patch gives back this functionality by keeping the default to daily invocation.