### PR TITLE
apt module with a list is more efficient

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,10 @@
 ---
 - name: install dependencies
   apt:
-    name: "{{ item }}"
+    name: "{{ logcheck_dependencies }}"
     state: "{{ apt_install_state | default('latest') }}"
     update_cache: true
     cache_valid_time: "{{ apt_update_cache_valid_time | default(3600) }}"
-  with_items: "{{ logcheck_dependencies }}"
   tags:
     - configuration
     - logcheck
@@ -14,9 +13,8 @@
 
 - name: install additional
   apt:
-    name: "{{ item }}"
+    name: "{{ logcheck_install }}"
     state: "{{ apt_install_state | default('latest') }}"
-  with_items: "{{ logcheck_install }}"
   tags:
     - configuration
     - logcheck


### PR DESCRIPTION
It also avoids a deprecation warning. Certainly works 2.5 upwards. Documentation for 2.7 (which deprecated the loop) suggests it works since 2.3

fixes #10 
